### PR TITLE
Spiffy: add missing build dependency

### DIFF
--- a/packages/dev-perl/Spiffy/Spiffy-0.31.exheres-0
+++ b/packages/dev-perl/Spiffy/Spiffy-0.31.exheres-0
@@ -9,4 +9,7 @@ SLOT="0"
 PLATFORMS="~amd64"
 MYOPTIONS=""
 
-DEPENDENCIES=""
+DEPENDENCIES="
+    build:
+        dev-perl/Module-Package
+"


### PR DESCRIPTION
Identified by the CI:
    Can't locate inc/Module/Package.pm in @INC (you may need to
        install the inc::Module::Package module)
Log:
    https://gitlab.exherbo.org/tureba/arbor/-/jobs/3984/raw